### PR TITLE
support for imperfect monorepos

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -65,7 +65,7 @@ requires = ["hatchling", "hatch-una"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.hooks.una-build]
-[tool.hatch.build.hooks.una-meta]
+[tool.hatch.metadata.hooks.una-meta]
 ```
 
 4. Then you can build from that package directory and Una will inject everything that is needed:

--- a/plugins/hatch/hatch_una/util.py
+++ b/plugins/hatch/hatch_una/util.py
@@ -1,3 +1,4 @@
+import re
 import tomllib
 from pathlib import Path
 from typing import Any
@@ -27,23 +28,44 @@ def get_dependencies(path: Path) -> tuple[list[str], list[str]]:
     except KeyError as e:
         raise KeyError(f"No tool.uv.sources table for '{path}'") from e
 
+    sources = {_clean_dependency_name(k): v for k, v in sources.items()}
+
     ext_deps: list[str] = []
     int_deps: list[str] = []
     for d in all_deps:
-        if d in sources:
-            if sources[d]["workspace"]:
-                int_deps.append(d)
+        cleaned_dependency = _clean_dependency_name(d)
+        if cleaned_dependency in sources:
+            if sources[cleaned_dependency].get("workspace", False):
+                int_deps.append(cleaned_dependency)
                 continue
         ext_deps.append(d)
     return (ext_deps, int_deps)
 
 
+def _clean_dependency_name(dep: str) -> str:
+    """
+    python allows the interchange of underscores and dashes,
+    and the dependencies section could contain version specifiers.
+    Remove all such information before matching
+    """
+    dep = dep.replace("-", "_")
+    dep = re.sub(r"[^a-zA-Z0-9_].*", "", dep)
+    return dep
+
+
 def find_package_dir(name: str, members: list[str]) -> Path:
+    cleaned_name = _clean_dependency_name(name)
     root = get_workspace_root()
     for glob in members:
         packages = sorted(root.glob(glob))
         for p in packages:
-            if p.name == name:
+            try:
+                package_pyproject = tomllib.loads((p / "pyproject.toml").read_text())
+            except FileNotFoundError as e:
+                e.add_note(f"workspace member points to a location that has no pyproject.toml: {p}")
+                raise e
+            package_name = str(package_pyproject.get("project", {}).get("name", ""))  # pyright:ignore[reportAny]
+            if _clean_dependency_name(package_name) == cleaned_name:
                 return p.resolve()
     raise ValueError(f"Couldn't find package '{name}'")
 
@@ -58,6 +80,8 @@ def get_workspace_root() -> Path:
 def _find_upwards(cwd: Path) -> Path | None:
     if cwd == Path(cwd.root) or cwd == cwd.parent:
         return None
-    elif (cwd / ".git").exists():
-        return cwd
+    elif (pyproject := cwd / "pyproject.toml").exists():
+        conf = tomllib.loads(pyproject.read_text())
+        if "members" in conf.get("tool", {}).get("uv", {}).get("workspace", {}):  # pyright:ignore[reportAny]
+            return cwd
     return _find_upwards(cwd.parent)

--- a/plugins/hatch/hatch_una/util.py
+++ b/plugins/hatch/hatch_una/util.py
@@ -3,6 +3,7 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
+
 PYPROJ = "pyproject.toml"
 
 
@@ -23,10 +24,7 @@ def get_members() -> list[str]:
 def get_dependencies(path: Path) -> tuple[list[str], list[str]]:
     conf = load_conf(path)
     all_deps: list[str] = conf["project"].get("dependencies", [])  # pyright:ignore[reportAny]
-    try:
-        sources: dict[str, dict[str, bool]] = conf["tool"]["uv"]["sources"]
-    except KeyError as e:
-        raise KeyError(f"No tool.uv.sources table for '{path}'") from e
+    sources: dict[str, dict[str, bool]] = conf.get("tool", {}).get("uv", {}).get("sources", {})  # pyright:ignore[reportAny]
 
     sources = {_clean_dependency_name(k): v for k, v in sources.items()}
 

--- a/plugins/hatch/pyproject.toml
+++ b/plugins/hatch/pyproject.toml
@@ -11,14 +11,15 @@ requires-python = ">= 3.11"
 keywords = ["uv", "hatch", "monorepo", "build", "python"]
 
 classifiers = [
-  "Environment :: Console",
-  "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
-  "Operating System :: Unix",
-  "Programming Language :: Python",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: Unix",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Framework :: Hatch",
 ]
 
 dependencies = ["hatchling >= 1.25.0"]


### PR DESCRIPTION
* fix typo in docs
* Add Hatch to classifiers in pyproject
* find workspace root according to the `workspace` pyproject entry to allow workspaces that do not live in a git repo root
* clean dependency names before comparison: the `dependencies` section could be specifying `"foo-bar>=1.5"`, referencing a workspace member `foo_bar`.
* use package name from pyproject instead of folder name to match dependencies
* do not throw an error if a (file-)url based dependency is listed under `tool.uv.sources`